### PR TITLE
Fix _tkinter.TclError: bad screen distance "200.0" Crash on non english Windows systems

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,6 +11,28 @@ import random
 from tkinter import ttk
 from Arc_API.Arc_API import arc_API
 import customtkinter as ctk
+from typing import Union
+from customtkinter.windows.widgets.scaling import CTkScalingBaseClass
+
+# Patch based upon: https://github.com/TomSchimansky/CustomTkinter/issues/571#issuecomment-1823438190
+def apply_widget_scaling(self, value: Union[int, float]) -> Union[float, int]:
+    if hasattr(self, "__scaling_type"):
+        assert self.__scaling_type == "widget"
+    if isinstance(value, float):
+        return value * self._get_widget_scaling()
+    else:
+        return int(value * self._get_widget_scaling())
+
+def reverse_widget_scaling(self, value: Union[int, float]) -> Union[float, int]:
+    if hasattr(self, "__scaling_type"):
+        assert self.__scaling_type == "widget"
+    if isinstance(value, float):
+        return value / self._get_widget_scaling()
+    else:
+        return int(value / self._get_widget_scaling())
+
+CTkScalingBaseClass._apply_widget_scaling = apply_widget_scaling
+CTkScalingBaseClass._reverse_widget_scaling = reverse_widget_scaling
 
 def resource_path(relative_path):
     """ Fixes issues with PyInstaller """


### PR DESCRIPTION
This Pull Request adresses an issue with ctk, where the scaling wouldn`t correctly be calculated when using a non english language. The solution was already posted in: https://github.com/TomSchimansky/CustomTkinter/issues/571. It is also referenced in the code.

I just patched the class with the correted function.